### PR TITLE
Modifying page title to contain DukeCon

### DIFF
--- a/src/main/jbake/templates/header.gsp
+++ b/src/main/jbake/templates/header.gsp
@@ -1,6 +1,6 @@
   <head>
     <meta charset="utf-8"/>
-    <title><%if (content.title) {%>${content.title}<% } else { %>JBake<% }%></title>
+    <title><%if (content.title) {%>${content.title} - DukeCon<% } else { %>DukeCon - open source agenda tool for conferences<% }%></title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">


### PR DESCRIPTION
If you take a look at your website, the page title is "JBake". If you add it to your bookmarks, it will show up as "JBake". I replaced it with "DukeCon" and I added "DukeCon" to the end of the title of the other pages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dukecon/dukecon_webhome/16)
<!-- Reviewable:end -->
